### PR TITLE
Add README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,64 @@
+# ooxml-signature-pages
+
 Given an Array of signature page objects satisfying [signature-page-schema](https://www.npmjs.com/package/signature-page-schema), return a string of OOXML markup.
+
+```javascript
+var assert = require('assert')
+var signaturePages = require('ooxml-signature-pages')
+```
+
+## Blank Pages
+
+```javascript
+var blankPages = signaturePages([
+  {
+    header: (
+      'The parties are signing this agreement ' +
+      'on the dates by their signatures.'
+    ),
+    entities: [
+      {
+        name: 'SomeCo, Inc.',
+        form: 'corporation',
+        jurisdiction: 'Delaware',
+        by: 'Chief Executive Officer'
+      }
+    ],
+    information: ['date']
+  },
+  {
+    samePage: true,
+    information: ['date']
+  }
+])
+assert(typeof blankPages === 'string')
+```
+
+## Pre-Filled Pages
+
+```javascript
+var preFilled = signaturePages([
+  {
+    entities: [
+      {
+        name: 'SomeCo, Inc.',
+        form: 'corporation',
+        jurisdiction: 'Delaware',
+        by: 'Chief Executive Officer'
+      }
+    ],
+    name: 'Jane Manager',
+    information: {
+      date: 'January 1, 2019'
+    }
+  },
+  {
+    samePage: true,
+    name: 'John Doe',
+    information: {
+      date: 'January 2, 2019'
+    }
+  }
+])
+assert(typeof preFilled === 'string')
+```

--- a/package.json
+++ b/package.json
@@ -12,9 +12,12 @@
     "xml-escape": "^1.0.0"
   },
   "devDependencies": {
+    "defence-cli": "^3.0.1",
+    "replace-require-self": "^1.1.1",
     "standard": "^12.0.1"
   },
   "scripts": {
-    "lint": "standard"
+    "lint": "standard",
+    "test": "defence -i javascript README.md | replace-require-self | node"
   }
 }


### PR DESCRIPTION
@compleatang, this PR adds examples to the README for `ooxml-signature-pages`. Note that this package allows you to pass in data to pre-fill name and information fields.